### PR TITLE
fix #2

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -76,12 +76,6 @@ pub struct NexmarkConfig {
     pub num_categories: usize,
     /// Use to calculate the next auction id.
     pub auction_id_lead: usize,
-    /// Ratio of auctions for 'hot' sellers compared to all other people.
-    pub hot_seller_ratio_2: usize,
-    /// Ratio of bids to 'hot' auctions compared to all other auctions.
-    pub hot_auction_ratio_2: usize,
-    /// Ratio of bids for 'hot' bidders compared to all other people.
-    pub hot_bidder_ratio_2: usize,
     /// Person Proportion.
     pub person_proportion: usize,
     /// Auction Proportion.
@@ -141,9 +135,6 @@ impl Default for NexmarkConfig {
             first_event_number: 0,
             num_categories: 5,
             auction_id_lead: 10,
-            hot_seller_ratio_2: 100,
-            hot_auction_ratio_2: 100,
-            hot_bidder_ratio_2: 100,
             person_proportion: 1,
             auction_proportion: 3,
             bid_proportion: 46,

--- a/src/event.rs
+++ b/src/event.rs
@@ -25,6 +25,11 @@ use crate::utils::{NexmarkRng, CHANNEL_URL_MAP};
 
 type Id = usize;
 
+/// Fraction of people/auctions which may be 'hot' sellers/bidders/auctions are 1 over these values.
+const HOT_SELLER_RATIO: usize = 100;
+const HOT_AUCTION_RATIO: usize = 100;
+const HOT_BIDDER_RATIO: usize = 100;
+
 /// The type of a Nexmark event.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -187,7 +192,7 @@ impl Auction {
         let reserve = initial_bid + rng.gen_price();
         let expires = time + Self::next_length(event_number, rng, time, cfg);
         let mut seller = if rng.gen_range(0..cfg.hot_seller_ratio) > 0 {
-            (Person::last_id(id, cfg) / cfg.hot_seller_ratio_2) * cfg.hot_seller_ratio_2
+            (Person::last_id(id, cfg) / HOT_SELLER_RATIO) * HOT_SELLER_RATIO
         } else {
             Person::next_id(id, rng, cfg)
         };
@@ -274,12 +279,12 @@ impl Bid {
     pub(crate) fn new(id: usize, time: u64, nex: &GeneratorConfig) -> Self {
         let rng = &mut SmallRng::seed_from_u64(id as u64);
         let auction = if 0 < rng.gen_range(0..nex.hot_auction_ratio) {
-            (Auction::last_id(id, nex) / nex.hot_auction_ratio_2) * nex.hot_auction_ratio_2
+            (Auction::last_id(id, nex) / HOT_AUCTION_RATIO) * HOT_AUCTION_RATIO
         } else {
             Auction::next_id(id, rng, nex)
         };
         let bidder = if 0 < rng.gen_range(0..nex.hot_bidder_ratio) {
-            (Person::last_id(id, nex) / nex.hot_bidder_ratio_2) * nex.hot_bidder_ratio_2 + 1
+            (Person::last_id(id, nex) / HOT_BIDDER_RATIO) * HOT_BIDDER_RATIO + 1
         } else {
             Person::next_id(id, rng, nex)
         };

--- a/src/event.rs
+++ b/src/event.rs
@@ -142,14 +142,15 @@ impl Person {
         }
     }
 
-    /// Generate and return a random person with next available id.
+    /// Return a random person id (base 0).
     fn next_id(event_id: usize, rng: &mut SmallRng, nex: &GeneratorConfig) -> Id {
         let people = Self::last_id(event_id, nex) + 1;
         let active = people.min(nex.active_people);
         people - active + rng.gen_range(0..active + nex.person_id_lead)
     }
 
-    /// Return a random person id (base 0).
+    /// Return the last valid person id (ignoring FIRST_PERSON_ID). Will be the current person id if
+    /// due to generate a person.
     fn last_id(event_id: usize, nex: &GeneratorConfig) -> Id {
         let epoch = event_id / nex.proportion_denominator;
         let offset = (event_id % nex.proportion_denominator).min(nex.person_proportion - 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Singularity Data
+// Copyright 2023 Singularity Data
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix #2 and renamed `id` to `event_id` to avoid such mistakes

Also:

- Added some comments
- Deleted 3 arguments: `hot_seller_ratio_2` and so on because their names look confusing to users
